### PR TITLE
feat: add chinese

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -9,6 +9,13 @@ def signingKeyAlias = System.getenv("SIGNING_KEY_ALIAS")
 def signingKeyPassword = System.getenv("SIGNING_KEY_PASSWORD")
 def hasCiSigning = signingStorePath && signingStorePassword && signingKeyAlias && signingKeyPassword
 
+// res/values/strings.xml is the single English source of truth. Android treats the
+// unqualified values/ bucket as "no locale match", so with per-app locales the
+// effective list is [selected, system]: picking "en" finds no `en` bucket, falls
+// through to the system locale and resolves Chinese instead. Deriving a real `en`
+// bucket at build time keeps English selectable without duplicating the file in git.
+def generatedEnResDir = layout.buildDirectory.dir("generated/res/localeEn")
+
 android {
 	namespace = "org.vita3k.emulator"
 	compileSdk = 35
@@ -91,6 +98,9 @@ android {
 			java {
 				srcDirs += ['../../external/sdl/android-project/app/src/main/java']
 			}
+			res {
+				srcDirs += generatedEnResDir
+			}
 		}
 	}
 
@@ -109,6 +119,24 @@ android {
 		jniLibs {
 			useLegacyPackaging = true
 		}
+	}
+}
+
+// Derived resource: never edit, never commit. Regenerated from values/strings.xml
+// on every build, so the two can never drift.
+def copyEnStrings = tasks.register('copyEnStrings', Copy) {
+	from('src/main/res/values') {
+		include 'strings.xml'
+	}
+	into generatedEnResDir.map { it.dir('values-en') }
+}
+
+// Several AGP tasks consume the res source dirs (merge*Resources,
+// map*SourceSetPaths, process*NavigationResources, ...). Rather than enumerate
+// AGP internals, make every task that reads the generated dir depend on it.
+tasks.configureEach { task ->
+	if (task.name != 'copyEnStrings' && task.name =~ /(?i)(Resources|SourceSetPaths)$/) {
+		task.dependsOn copyEnStrings
 	}
 }
 

--- a/android/app/src/main/java/org/vita3k/emulator/data/UiLanguages.kt
+++ b/android/app/src/main/java/org/vita3k/emulator/data/UiLanguages.kt
@@ -15,7 +15,8 @@ object UiLanguages {
 
     val options: List<UiLanguageOption> = listOf(
         UiLanguageOption("", "System Default"),
-        UiLanguageOption("en", "English")
+        UiLanguageOption("en", "English"),
+        UiLanguageOption("zh-Hans", "简体中文")
     )
 
     fun currentTag(context: Context): String =

--- a/android/app/src/main/java/org/vita3k/emulator/ui/screens/settings/SettingsSections.kt
+++ b/android/app/src/main/java/org/vita3k/emulator/ui/screens/settings/SettingsSections.kt
@@ -1475,13 +1475,17 @@ private fun InterfaceSettingsSection(
     ) {
         SettingsSubsectionTitle(title = stringResource(R.string.settings_interface_ui_options))
         val uiLanguageTitle = stringResource(R.string.settings_emulator_ui_language)
+        val systemDefaultLabel = stringResource(R.string.settings_ui_language_system_default)
         val uiLanguageOptions = UiLanguages.options
+        val uiLanguageLabels = uiLanguageOptions.map { option ->
+            if (option.tag.isEmpty()) systemDefaultLabel else option.label
+        }
         val uiLanguageIndex = uiLanguageOptions.indexOfFirst { it.tag == cfg.userLang }.let { index ->
             if (index >= 0) index else 0
         }
         SettingsScrollableChoiceField(
             title = uiLanguageTitle,
-            options = uiLanguageOptions.map { it.label },
+            options = uiLanguageLabels,
             selectedIndex = uiLanguageIndex,
             onSelect = { index -> onUpdate { userLang = uiLanguageOptions[index].tag } },
             help = SettingsHelpEntry(

--- a/android/app/src/main/res/values-b+zh+Hans/strings.xml
+++ b/android/app/src/main/res/values-b+zh+Hans/strings.xml
@@ -1,0 +1,747 @@
+<resources>
+    <!-- App name -->
+    <string name="app_name">Vita3K</string>
+
+    <!-- Common actions -->
+    <string name="action_ok">确定</string>
+    <string name="action_cancel">取消</string>
+    <string name="action_delete">删除</string>
+    <string name="action_yes">是</string>
+    <string name="action_no">否</string>
+    <string name="action_back">返回</string>
+    <string name="action_install">安装</string>
+
+    <!-- Compatibility states -->
+    <string name="compat_unknown">未知</string>
+    <string name="compat_nothing">无法运行</string>
+    <string name="compat_bootable">可启动</string>
+    <string name="compat_intro">进入开场</string>
+    <string name="compat_menu">进入菜单</string>
+    <string name="compat_ingame_less">可进游戏−</string>
+    <string name="compat_ingame_more">可进游戏+</string>
+    <string name="compat_playable">可玩</string>
+
+    <!-- App action groups -->
+    <string name="action_group_delete">删除</string>
+    <string name="action_group_other">其他</string>
+
+    <!-- App action labels -->
+    <string name="app_action_application">应用程序</string>
+    <string name="app_action_save_data">存档数据</string>
+    <string name="app_action_patch">补丁</string>
+    <string name="app_action_dlc">DLC</string>
+    <string name="app_action_license">许可证</string>
+    <string name="app_action_shader_cache">着色器缓存</string>
+    <string name="app_action_shader_log">着色器日志</string>
+    <string name="app_action_export_textures">导出纹理</string>
+    <string name="app_action_import_textures">导入纹理</string>
+    <string name="app_action_reset_last_played">重置最近游玩记录</string>
+
+    <!-- Apps list screen -->
+    <string name="apps_list_app_title">Vita3K</string>
+    <plurals name="apps_list_n_selected">
+        <item quantity="one">已选择 %1$d 项</item>
+        <item quantity="other">已选择 %1$d 项</item>
+    </plurals>
+    <string name="apps_list_cd_install">安装</string>
+    <string name="apps_list_cd_exit_selection">退出选择模式</string>
+    <string name="apps_list_cd_select_all">全选</string>
+    <string name="apps_list_cd_delete_selected">删除所选项</string>
+    <string name="apps_list_cd_search">搜索</string>
+    <string name="apps_list_cd_sort">排序</string>
+    <string name="apps_list_cd_toggle_view">切换视图</string>
+    <string name="apps_list_cd_refresh">刷新</string>
+    <string name="apps_list_cd_more_options">更多选项</string>
+    <string name="apps_list_cd_close_search">关闭搜索</string>
+    <string name="apps_list_cd_selected">已选择</string>
+    <string name="apps_list_menu_users">用户管理</string>
+    <string name="apps_list_menu_welcome">欢迎界面</string>
+    <string name="apps_list_menu_check_updates">检查更新</string>
+    <string name="apps_list_menu_about">关于</string>
+    <string name="apps_list_menu_trophies">奖杯收藏</string>
+    <string name="apps_list_search_placeholder">搜索应用\u2026</string>
+    <string name="apps_list_sort_title">标题</string>
+    <string name="apps_list_sort_last_played">最近游玩</string>
+    <string name="apps_list_sort_compatibility">兼容性</string>
+    <string name="apps_list_custom_config_badge">CC</string>
+    <string name="apps_list_empty_search">没有匹配 \"%1$s\" 的应用</string>
+    <string name="apps_list_empty_missing_firmware">缺少固件组件：%1$s</string>
+    <string name="apps_list_empty_firmware_title">需要安装固件</string>
+    <string name="apps_list_empty_firmware_body">请安装缺少的 PS Vita 固件组件，以便应用能够正常运行。</string>
+    <string name="apps_list_empty_firmware_missing_list_title">缺少的组件</string>
+    <string name="apps_list_empty_no_firmware">未安装固件</string>
+    <string name="apps_list_empty_missing_main_firmware">未安装主固件</string>
+    <string name="apps_list_empty_no_apps">未安装应用</string>
+    <string name="apps_list_install_firmware">安装固件</string>
+    <string name="apps_list_install_app">安装应用</string>
+    <string name="apps_list_init_failed">模拟器初始化失败。</string>
+
+    <!-- App actions menu -->
+    <string name="app_menu_information">信息</string>
+    <string name="app_menu_delete">删除\u2026</string>
+    <string name="app_menu_custom_config">自定义配置</string>
+
+    <!-- User management -->
+    <string name="user_management_title">用户管理</string>
+    <string name="user_management_refresh">刷新用户列表</string>
+    <string name="user_management_active_user">当前用户</string>
+    <string name="user_management_active_none">未选择用户</string>
+    <string name="user_management_active_badge">使用中</string>
+    <string name="user_management_create_user">创建用户</string>
+    <string name="user_management_create_prompt">创建一个本地 Vita 用户配置文件，用于保存存档、游玩记录和应用数据。</string>
+    <string name="user_management_name_label">用户名</string>
+    <string name="user_management_switch_user">选择用户</string>
+    <string name="user_management_delete_user">删除用户</string>
+    <string name="user_management_delete_title">删除用户</string>
+    <string name="user_management_delete_message">确定要删除用户 \"%1$s\" 吗？\n\n该用户的所有数据都将丢失。</string>
+    <string name="user_management_empty_title">未找到用户</string>
+    <string name="user_management_empty_message">创建一个用户即可开始保存存档和游玩记录。</string>
+    <string name="user_management_created_success">已创建用户 %1$s。</string>
+    <string name="user_management_selected_success">已选择用户 %1$s。</string>
+    <string name="user_management_deleted_success">已删除用户 %1$s。</string>
+    <string name="user_management_create_failed">创建用户失败。</string>
+    <string name="user_management_select_failed">选择用户失败。</string>
+    <string name="user_management_delete_failed">删除用户失败。</string>
+
+    <!-- Batch delete dialog -->
+    <plurals name="batch_delete_title">
+        <item quantity="one">删除 %1$d 个应用</item>
+        <item quantity="other">删除 %1$d 个应用</item>
+    </plurals>
+    <plurals name="batch_delete_message">
+        <item quantity="one">确定要删除所选的 %1$d 个应用吗？\n\n此操作无法撤销。</item>
+        <item quantity="other">确定要删除所选的 %1$d 个应用吗？\n\n此操作无法撤销。</item>
+    </plurals>
+
+    <!-- Action confirm dialog -->
+    <string name="confirm_delete_title">删除%1$s</string>
+    <string name="confirm_delete_message">这将永久删除该应用的%1$s。此操作无法撤销。</string>
+    <string name="confirm_reset_playtime_title">重置游玩时间</string>
+    <string name="confirm_reset_playtime_message">确定要重置 %1$s 的游玩时间吗？</string>
+    <string name="confirm_reset_playtime_this_app">该应用</string>
+
+    <!-- Action progress / result -->
+    <string name="action_deleting">正在删除%1$s\u2026</string>
+    <string name="action_applying">正在执行操作\u2026</string>
+    <string name="action_done">完成</string>
+    <string name="action_reset">重置</string>
+    <plurals name="batch_delete_success">
+        <item quantity="one">已删除 %1$d 个应用。</item>
+        <item quantity="other">已删除 %1$d 个应用。</item>
+    </plurals>
+    <string name="batch_delete_partial">已删除 %2$d 个应用中的 %1$d 个。</string>
+    <string name="action_deleted_success">已删除 %2$s 的%1$s。</string>
+    <string name="action_deleted_failed">删除 %2$s 的%1$s失败。</string>
+
+    <!-- App info sheet -->
+    <string name="app_info_title">应用信息</string>
+    <string name="app_info_cd_close">关闭</string>
+    <string name="app_info_field_title">标题</string>
+    <string name="app_info_field_serial">序号</string>
+    <string name="app_info_field_app_version">应用版本</string>
+    <string name="app_info_field_category">类别</string>
+    <string name="app_info_field_install_size">安装大小</string>
+    <string name="app_info_field_play_time">游玩时间</string>
+    <string name="app_info_field_last_played">最近游玩</string>
+    <string name="app_info_size_calculating">正在计算\u2026</string>
+    <string name="app_info_size_unknown">未知</string>
+    <string name="app_info_size_kb">%1$d KB</string>
+    <string name="app_info_size_mb">%1$.1f MB</string>
+    <string name="app_info_size_gb">%1$.2f GB</string>
+    <string name="app_info_playtime_never">从未游玩</string>
+    <string name="app_info_playtime_hm">%1$d 小时 %2$d 分</string>
+    <string name="app_info_playtime_ms">%1$d 分 %2$d 秒</string>
+    <string name="app_info_playtime_s">%1$d 秒</string>
+    <string name="app_info_last_played_never">从未</string>
+
+    <!-- About sheet -->
+    <string name="about_build">版本：%1$s</string>
+    <string name="about_revision">修订版本：%1$s</string>
+    <string name="about_legal_notice">Vita3K 不支持任何盗版行为。请使用您自行导出的游戏。</string>
+
+    <!-- Updates -->
+    <string name="updates_check_title">检查更新</string>
+    <string name="updates_check_progress">正在检查更新…</string>
+    <string name="updates_check_in_progress">更新检查已在进行中。</string>
+    <string name="updates_available_title">有可用更新</string>
+    <string name="updates_official_available_title">有可用的官方版本</string>
+    <string name="updates_latest_build">最新版本</string>
+    <string name="updates_open_download_page">打开下载页面</string>
+    <string name="updates_summary_available">有更新的 Vita3K 版本可用。\n\n当前版本：%1$s\n最新版本：%2$s</string>
+    <string name="updates_summary_available_with_date">有更新的 Vita3K 版本可用。\n\n当前版本：%1$s\n最新版本：%2$s\n发布时间：%3$s</string>
+    <string name="updates_summary_custom_build">您当前运行的是非官方版本或 PR 版本。\n\n如果更新，将切换到最新的官方版本，不再使用当前的自定义版本或 PR 版本。\n\n最新官方版本：%1$s</string>
+    <string name="updates_summary_custom_build_with_date">您当前运行的是非官方版本或 PR 版本。\n\n如果更新，将切换到最新的官方版本，不再使用当前的自定义版本或 PR 版本。\n\n最新官方版本：%1$s\n发布时间：%2$s</string>
+
+    <!-- Initial setup -->
+    <string name="initial_setup_welcome_title">欢迎使用 Vita3K</string>
+    <string name="initial_setup_welcome_body">Vita3K 是一款使用 C++ 编写的开源 PlayStation Vita 模拟器，支持 Windows、Linux、macOS 和 Android。模拟器仍在积极开发中，非常欢迎您的反馈和测试。</string>
+    <string name="initial_setup_piracy_notice">Vita3K 不支持任何盗版行为。请使用您自行导出的游戏。</string>
+    <string name="initial_setup_firmware_title">安装固件</string>
+    <string name="initial_setup_firmware_body">开始之前，请先安装下面的 PS Vita 固件文件。</string>
+    <string name="initial_setup_preinstall_title">预安装包</string>
+    <string name="initial_setup_main_title">主固件</string>
+    <string name="initial_setup_font_title">字体包</string>
+    <string name="initial_setup_download">下载</string>
+    <string name="initial_setup_install_pup">安装</string>
+    <string name="initial_setup_select_firmware_language">选择固件语言</string>
+    <string name="initial_setup_status_installed">已安装</string>
+    <string name="initial_setup_status_missing">缺失</string>
+    <string name="initial_setup_status_optional">可选</string>
+    <string name="initial_setup_back">上一步</string>
+    <string name="initial_setup_next">下一步</string>
+    <string name="initial_setup_skip">暂时跳过</string>
+    <string name="initial_setup_open_library">打开游戏库</string>
+
+    <!-- In-game pause menu -->
+    <string name="emulation_menu_title">已暂停</string>
+    <string name="emulation_menu_subtitle">游戏进行中</string>
+    <string name="emulation_menu_close">关闭暂停菜单</string>
+    <string name="emulation_tab_session">会话</string>
+    <string name="emulation_tab_controls">触屏按键</string>
+    <string name="emulation_tab_controller">手柄</string>
+    <string name="emulation_tab_settings">设置</string>
+    <string name="emulation_resume">继续</string>
+    <string name="emulation_pause">暂停</string>
+    <string name="emulation_exit">退出</string>
+    <string name="emulation_exit_title">退出游戏？</string>
+    <string name="emulation_exit_message">所有未保存的游戏进度都将丢失。</string>
+    <string name="emulation_custom_config">自定义配置</string>
+    <string name="emulation_custom_config_active">该游戏已保存自定义配置。</string>
+    <string name="emulation_custom_config_inactive">该游戏正在使用全局设置。</string>
+    <string name="emulation_create_config_short">创建</string>
+    <string name="emulation_save_config_short">保存</string>
+    <string name="emulation_reset_config_short">重置</string>
+    <string name="emulation_open_settings_short">全部设置</string>
+    <string name="emulation_settings_saved">设置已保存。</string>
+    <string name="emulation_controls_show">显示触屏按键</string>
+    <string name="emulation_controls_l2r2">显示 L2 / R2</string>
+    <string name="emulation_controls_l3r3">显示 L3 / R3</string>
+    <string name="emulation_controls_touch_switch">触摸屏切换按钮</string>
+    <string name="emulation_controls_hide_toggle">隐藏切换按钮</string>
+    <string name="emulation_controls_scale">按键大小</string>
+    <string name="emulation_controls_opacity">按键不透明度</string>
+    <string name="emulation_controls_edit">编辑布局</string>
+    <string name="emulation_controls_done">完成</string>
+    <string name="emulation_controls_reset_layout">重置布局</string>
+    <string name="emulation_controls_editor_title">编辑触屏按键</string>
+    <string name="emulation_runtime_note">部分设置需要重新启动游戏后才会生效。</string>
+    <string name="settings_restart_required_title">需要重启</string>
+    <string name="settings_restart_required_summary">部分改动需要重启应用才能完全生效。</string>
+    <string name="settings_restart_required_message">以下已更改的设置将在重启后生效：\n- %1$s</string>
+    <string name="settings_restart_app">重启应用</string>
+    <string name="settings_restart_later">稍后重启</string>
+    <string name="settings_restart_in_progress_title">正在重启应用</string>
+    <string name="settings_restart_in_progress_message">请稍等，Vita3K 正在重新启动游戏。</string>
+    <string name="settings_restart_game">重启游戏</string>
+    <string name="settings_continue_playing">继续游戏</string>
+    <string name="emulation_ime_placeholder">开始输入…</string>
+
+    <!-- Install bottom sheet -->
+    <string name="install_sheet_title">安装内容</string>
+    <string name="install_firmware_title">固件（PUP）</string>
+    <string name="install_firmware_desc">安装 PS Vita 固件</string>
+    <string name="install_pkg_title">安装包（PKG）</string>
+    <string name="install_pkg_desc">安装 .pkg 应用或 DLC</string>
+    <string name="install_archive_title">压缩包（ZIP/VPK）</string>
+    <string name="install_archive_desc">从 .zip 或 .vpk 文件安装</string>
+    <string name="install_license_title">许可证</string>
+    <string name="install_license_desc">安装 .rif 或 .bin 许可证文件</string>
+    <string name="install_progress_title">正在安装</string>
+    <string name="install_result_success_title">安装成功</string>
+    <string name="install_result_partial_title">安装结束</string>
+    <string name="install_result_failed_title">安装失败</string>
+    <string name="install_notification_channel_name">安装进度</string>
+    <string name="install_notification_channel_desc">在 Vita3K 退至后台时保持内容安装继续进行。</string>
+    <string name="install_archive_source_title">安装压缩包</string>
+    <string name="install_archive_source_message">选择单个压缩包文件，或选择包含多个 .zip 与 .vpk 压缩包的文件夹。</string>
+    <string name="install_archive_source_file">选择压缩包文件</string>
+    <string name="install_archive_source_folder">选择压缩包文件夹</string>
+    <string name="install_license_source_title">安装许可证</string>
+    <string name="install_license_source_message">选择许可证文件，或手动输入 zRIF 密钥。</string>
+    <string name="install_delete_firmware_file">安装后删除固件文件</string>
+    <string name="install_delete_package_file">安装后删除安装包文件</string>
+    <string name="install_delete_archive_files">安装后删除压缩包文件</string>
+    <string name="install_delete_license_file">安装后删除许可证文件</string>
+
+    <!-- zRIF / license dialogs -->
+    <string name="zrif_dialog_title">输入 zRIF 密钥</string>
+    <string name="zrif_dialog_hint">zRIF</string>
+    <string name="license_required_title">需要许可证</string>
+    <string name="license_required_message">未自动找到许可证。\n您希望以何种方式提供？</string>
+    <string name="license_select_file">选择 .bin / .rif 文件</string>
+    <string name="license_enter_zrif">手动输入 zRIF 密钥</string>
+
+    <!-- Install status messages (ViewModel) -->
+    <string name="install_status_firmware">正在安装固件\u2026</string>
+    <string name="install_status_preparing">正在准备\u2026</string>
+    <string name="install_status_package">正在安装安装包\u2026</string>
+    <string name="install_status_archive">正在安装压缩包\u2026</string>
+    <string name="install_status_archive_batch">正在安装第 %1$d / %2$d 个压缩包：%3$s\u2026</string>
+    <string name="install_status_license">正在安装许可证\u2026</string>
+    <string name="install_success_firmware">固件 %1$s 安装成功。</string>
+    <string name="install_failed_firmware">固件安装失败。</string>
+    <string name="install_success_package">安装包安装成功。</string>
+    <string name="install_failed_package">安装包安装失败。</string>
+    <string name="install_success_archive">压缩包安装成功。</string>
+    <string name="install_failed_archive">压缩包安装失败。</string>
+    <string name="install_success_archive_batch">已成功安装 %1$d 个压缩包。</string>
+    <string name="install_partial_archive_batch">压缩包安装结束。成功 %1$d 个，失败 %2$d 个。</string>
+    <string name="install_failed_archive_batch">有 %1$d 个文件安装失败。</string>
+    <string name="install_success_license">许可证安装成功。</string>
+    <string name="install_failed_license">许可证安装失败。</string>
+    <string name="install_failed_license_zrif">无法根据 zRIF 密钥创建许可证。</string>
+    <string name="install_error_archive_folder_empty">所选文件夹中没有 .zip 或 .vpk 压缩包。</string>
+    <string name="install_error_read_license">读取许可证文件失败。</string>
+    <string name="install_error_pkg_path_lost">内部错误：PKG 路径丢失。</string>
+    <string name="install_error_generic">错误：%1$s</string>
+
+    <!-- Filter / sort sheet -->
+    <string name="filter_title">筛选与视图</string>
+    <string name="filter_section_sort">排序方式</string>
+    <string name="filter_section_view">显示方式</string>
+    <string name="filter_view_list">列表</string>
+    <string name="filter_view_grid">网格</string>
+    <string name="filter_cd_open">筛选</string>
+
+    <!-- Settings screen — general -->
+    <string name="settings_title">设置</string>
+    <string name="settings_cd_open">打开设置</string>
+    <string name="settings_custom_config_label">设置 - %1$s</string>
+    <string name="settings_custom_config_banner">正在为该应用使用自定义配置</string>
+    <string name="settings_delete_custom_config">删除自定义配置</string>
+    <string name="settings_clear_all_custom_configs">清除所有自定义配置</string>
+    <string name="settings_confirm_delete_custom_config_title">删除自定义配置？</string>
+    <string name="settings_confirm_delete_custom_config_message">这将移除 %1$s 的自定义配置，并恢复使用全局设置。</string>
+    <string name="settings_confirm_clear_all_title">清除所有自定义配置？</string>
+    <string name="settings_confirm_clear_all_message">这将移除所有按应用保存的自定义配置文件。此操作无法撤销。</string>
+    <string name="settings_clear_all_custom_configs_success">已清除 %1$d 个自定义配置。</string>
+    <string name="settings_unsaved_title">未保存的更改</string>
+    <string name="settings_unsaved_message">您有尚未保存的更改，要如何处理？</string>
+    <string name="settings_discard">放弃更改</string>
+    <string name="settings_reset_defaults">恢复默认值</string>
+    <string name="settings_confirm_reset_defaults_title">将设置恢复为默认值？</string>
+    <string name="settings_confirm_reset_defaults_message">这会将当前设置表单恢复为模拟器默认值。存储文件夹的更改不受影响，需要单独修改。</string>
+    <string name="settings_reset_defaults_done">设置已恢复为默认值。</string>
+    <string name="settings_save_and_exit">保存并退出</string>
+    <string name="settings_save_cd">保存设置</string>
+    <string name="settings_more_options">更多选项</string>
+    <string name="settings_search_placeholder">搜索设置\u2026</string>
+    <string name="settings_search_results">搜索结果</string>
+    <string name="settings_search_no_results">没有匹配的设置。</string>
+    <string name="settings_success_title">成功</string>
+    <string name="settings_scope_global">仅全局设置</string>
+    <string name="settings_scope_per_app">仅单应用设置</string>
+    <string name="settings_value_enabled">已启用</string>
+    <string name="settings_value_disabled">已禁用</string>
+    <string name="settings_cd_show_info">显示设置详情</string>
+
+    <!-- Settings tabs -->
+    <string name="settings_tab_core">核心</string>
+    <string name="settings_tab_cpu">CPU</string>
+    <string name="settings_tab_gpu">图形</string>
+    <string name="settings_tab_audio">音频</string>
+    <string name="settings_tab_system">系统</string>
+    <string name="settings_tab_controls">操作</string>
+    <string name="settings_tab_interface">界面</string>
+    <string name="settings_tab_network">网络</string>
+    <string name="settings_tab_debug">调试</string>
+    <string name="settings_tab_emulator">模拟器</string>
+
+    <!-- Settings — Core tab -->
+    <string name="settings_modules_mode">模块加载模式</string>
+    <string name="settings_modules_automatic">自动</string>
+    <string name="settings_modules_automatic_desc">自动选择要加载的模块。推荐大多数应用使用。</string>
+    <string name="settings_modules_auto_manual">自动与手动</string>
+    <string name="settings_modules_auto_manual_desc">选择该模式后，除自动加载模块外，还会加载右侧列表中所选的模块。</string>
+    <string name="settings_modules_manual">手动</string>
+    <string name="settings_modules_manual_desc">仅加载列表中所选的模块。仅建议高级用户使用。</string>
+    <string name="settings_modules_list_title">LLE 模块列表</string>
+    <string name="settings_modules_search">搜索模块\u2026</string>
+    <string name="settings_modules_no_firmware">没有可用模块。请先安装固件。</string>
+    <string name="settings_modules_firmware_language">固件语言</string>
+    <string name="settings_modules_firmware_language_desc">选择要在浏览器中打开的 PlayStation 固件页面语言。</string>
+    <string name="settings_modules_download_firmware">下载固件</string>
+    <string name="settings_core_module_management">模块管理</string>
+
+    <!-- Settings — CPU tab -->
+    <string name="settings_cpu_opt">启用 CPU 优化</string>
+    <string name="settings_cpu_opt_desc">启用 Dynarmic JIT 优化，可提升性能。</string>
+    <string name="settings_cpu_dynarmic_settings">Dynarmic 设置</string>
+
+    <!-- Settings — GPU tab -->
+    <string name="settings_gpu_renderer_section">渲染器</string>
+    <string name="settings_gpu_image_quality">画面质量</string>
+    <string name="settings_gpu_textures_shaders">纹理与着色器</string>
+    <string name="settings_gpu_shaders">着色器</string>
+    <string name="settings_gpu_hacks">Hack 选项</string>
+    <string name="settings_gpu_android_driver_section">自定义 GPU 驱动</string>
+    <string name="settings_gpu_backend">后端渲染器</string>
+    <string name="settings_gpu_backend_desc">选择首选的后端渲染器。大多数设备推荐使用 Vulkan。</string>
+    <string name="settings_gpu_graphics_device">图形设备</string>
+    <string name="settings_gpu_accuracy">渲染精度</string>
+    <string name="settings_gpu_accuracy_desc">设置 Vulkan 的渲染精度等级。高精度可能改善画面表现，但会降低性能。</string>
+    <string name="settings_gpu_accuracy_standard">标准</string>
+    <string name="settings_gpu_accuracy_high">高</string>
+    <string name="settings_gpu_vsync">垂直同步</string>
+    <string name="settings_gpu_vsync_desc">为 OpenGL 启用垂直同步，可减少画面撕裂。</string>
+    <string name="settings_gpu_disable_surface_sync">禁用表面同步</string>
+    <string name="settings_gpu_disable_surface_sync_desc">速度 Hack，禁用后将关闭 CPU 与 GPU 之间的表面同步。\n少数游戏需要表面同步。\n禁用后可大幅提升性能（尤其在开启分辨率提升时）。</string>
+    <string name="settings_gpu_async_pipeline">异步管线编译</string>
+    <string name="settings_gpu_async_pipeline_desc">允许在多个并发线程上同时编译管线。\n这会减少管线编译造成的卡顿，代价是可能出现短暂的画面异常。</string>
+    <string name="settings_gpu_screen_filter">画面滤镜</string>
+    <string name="settings_gpu_screen_filter_desc">选择要应用于最终画面的滤镜。</string>
+    <string name="settings_gpu_resolution">内部分辨率提升</string>
+    <string name="settings_gpu_resolution_desc">按倍数缩放游戏渲染分辨率。\n实验性功能：应用在高于 1x 时不保证正常渲染。</string>
+    <string name="settings_gpu_resolution_val">%1$d\u00D7%2$d (%3$s\u00D7)</string>
+    <string name="settings_gpu_anisotropic">各向异性过滤</string>
+    <string name="settings_gpu_anisotropic_desc">用于提升相对视角倾斜的纹理清晰度的技术。\n没有明显缺点，但在较旧的 GPU 上可能影响性能。</string>
+    <string name="settings_gpu_textures">纹理</string>
+    <string name="settings_gpu_export_textures">导出纹理</string>
+    <string name="settings_gpu_export_textures_desc">将应用使用的纹理导出到 textures 文件夹。</string>
+    <string name="settings_gpu_import_textures">导入纹理</string>
+    <string name="settings_gpu_import_textures_desc">从 textures 文件夹导入替换纹理。</string>
+    <string name="settings_gpu_texture_format">纹理导出格式</string>
+    <string name="settings_gpu_texture_format_desc">导出纹理所使用的格式</string>
+    <string name="settings_gpu_fps_hack">帧率 Hack</string>
+    <string name="settings_gpu_fps_hack_desc">游戏 Hack。可能让部分游戏的帧率从 30 FPS 翻倍到 60 FPS，\n但也可能导致某些游戏运行速度加快一倍。</string>
+    <string name="settings_gpu_turbo_mode">Turbo 模式</string>
+    <string name="settings_gpu_turbo_mode_desc">强制 GPU 以尽可能高的频率运行。温度限制仍然有效。</string>
+    <string name="settings_gpu_shader_cache">启用着色器缓存</string>
+    <string name="settings_gpu_shader_cache_desc">启用着色器缓存，可减少后续运行时的卡顿。</string>
+    <string name="settings_gpu_spirv_shader">使用 SPIR-V 着色器（已弃用）</string>
+    <string name="settings_gpu_spirv_shader_desc">将生成的 SPIR-V 着色器直接传给驱动。\n请注意，部分有益的扩展将被禁用，且并非所有 GPU 都兼容此选项。</string>
+    <string name="settings_gpu_memory_mapping">内存映射</string>
+    <string name="settings_gpu_memory_mapping_desc">内存映射可提升性能、降低内存占用并修复许多图形问题。但在部分 GPU 上可能不稳定。</string>
+    <string name="settings_gpu_custom_driver">自定义 GPU 驱动</string>
+    <string name="settings_gpu_custom_driver_desc">选择要注入的已安装自定义 GPU 驱动。安装驱动需要兼容的 Android GPU 驱动 ZIP 包以及受支持的高通 Vulkan 驱动栈。</string>
+    <string name="settings_gpu_custom_driver_default">默认</string>
+    <string name="settings_gpu_custom_driver_missing">%1$s（已缺失）</string>
+    <string name="settings_gpu_custom_driver_missing_desc">所选的自定义驱动已不存在。请在启动应用前选择“默认”、重新安装该驱动，或选择其他已安装的驱动。</string>
+    <string name="settings_gpu_custom_driver_active_desc">所选的自定义驱动已加载并生效。</string>
+    <string name="settings_gpu_custom_driver_fallback_desc">所选的自定义驱动无法加载，Vita3K 已改用系统默认驱动。</string>
+    <string name="settings_gpu_download_custom_driver">下载驱动</string>
+    <string name="settings_gpu_install_custom_driver">安装驱动</string>
+    <string name="settings_gpu_remove_custom_driver">移除所选驱动</string>
+    <string name="settings_gpu_memory_mapping_unsupported">当前设备不支持内存映射。</string>
+    <string name="settings_gpu_custom_driver_resolve_failed">无法解析自定义驱动压缩包的路径。</string>
+    <string name="settings_gpu_custom_driver_install_success">已安装并加载自定义驱动 %1$s。</string>
+    <string name="settings_gpu_custom_driver_install_fallback">已安装自定义驱动 %1$s，但无法加载。Vita3K 已改用系统默认驱动。</string>
+    <string name="settings_gpu_custom_driver_install_failed">安装所选的自定义驱动压缩包失败。</string>
+    <string name="settings_gpu_custom_driver_selected_success">已成功加载自定义驱动 %1$s。</string>
+    <string name="settings_gpu_custom_driver_selected_fallback">加载自定义驱动 %1$s 失败。Vita3K 已改用系统默认驱动。</string>
+    <string name="settings_gpu_custom_driver_remove_success">已移除自定义驱动 %1$s。</string>
+    <string name="settings_gpu_custom_driver_remove_failed">移除自定义驱动 %1$s 失败。</string>
+    <string name="settings_confirm_remove_custom_driver_title">移除自定义驱动？</string>
+    <string name="settings_confirm_remove_custom_driver_message">这将从设备存储中永久移除已安装的自定义驱动 %1$s。</string>
+
+    <!-- Settings — Audio tab -->
+    <string name="settings_audio_output">音频输出</string>
+    <string name="settings_audio_features">功能</string>
+    <string name="settings_audio_settings_section">音频设置</string>
+    <string name="settings_audio_backend">音频后端</string>
+    <string name="settings_audio_backend_desc">选择音频后端。\n大多数设备推荐使用 Cubeb。</string>
+    <string name="settings_audio_volume">音量</string>
+    <string name="settings_audio_volume_desc">设置游戏内的音频音量。</string>
+    <string name="settings_audio_volume_value">当前音量：%1$d%%</string>
+    <string name="settings_audio_ngs">启用 NGS 支持</string>
+    <string name="settings_audio_ngs_desc">启用高级音频库 NGS 支持。</string>
+
+    <!-- Settings — Camera tab -->
+    <string name="settings_tab_camera">摄像头</string>
+    <string name="settings_camera_sources_section">摄像头来源</string>
+    <string name="settings_camera_front">前置摄像头</string>
+    <string name="settings_camera_front_desc">选择前置摄像头来源。也可使用纯色或静态图片作为替代。</string>
+    <string name="settings_camera_back">后置摄像头</string>
+    <string name="settings_camera_back_desc">选择后置摄像头来源。也可使用纯色或静态图片作为替代。</string>
+    <string name="settings_camera_source">摄像头来源</string>
+    <string name="settings_camera_solid_color">纯色</string>
+    <string name="settings_camera_static_image">静态图片</string>
+    <string name="settings_camera_color">摄像头颜色</string>
+    <string name="settings_camera_color_desc">选择摄像头来源为“纯色”时使用的替代颜色。</string>
+    <string name="settings_camera_image">摄像头图片</string>
+    <string name="settings_camera_image_desc">选择摄像头来源为“静态图片”时使用的替代图片。</string>
+    <string name="settings_camera_no_devices">未检测到摄像头设备。</string>
+    <string name="settings_camera_no_image">未选择图片</string>
+    <string name="settings_camera_image_resolve_failed">无法解析所选摄像头图片的路径。</string>
+
+    <!-- Settings — System tab -->
+    <string name="settings_system_console_settings">主机设置</string>
+    <string name="settings_system_system_modes">系统模式</string>
+    <string name="settings_system_region_language">地区与语言</string>
+    <string name="settings_system_system_settings_section">系统设置</string>
+    <string name="settings_system_enter_button">确定键分配</string>
+    <string name="settings_system_enter_button_desc">选择作为确定键的按钮。部分应用会忽略此设置。</string>
+    <string name="settings_system_enter_circle">圆圈</string>
+    <string name="settings_system_enter_cross">叉</string>
+    <string name="settings_system_pstv_mode">PlayStation TV 模式（PSTV）</string>
+    <string name="settings_system_pstv_mode_desc">启用 PlayStation TV 模式。</string>
+    <string name="settings_system_show_mode">展示模式</string>
+    <string name="settings_system_show_mode_desc">启用展示模式。</string>
+    <string name="settings_system_demo_mode">演示模式</string>
+    <string name="settings_system_demo_mode_desc">启用演示模式。</string>
+    <string name="settings_system_language">系统语言</string>
+    <string name="settings_system_language_desc">设置向应用程序报告的系统语言。</string>
+    <string name="settings_system_date_format">日期格式</string>
+    <string name="settings_system_date_format_desc">设置模拟系统使用的日期格式。</string>
+    <string name="settings_system_time_format">时间格式</string>
+    <string name="settings_system_time_format_desc">设置模拟系统使用的时间格式。</string>
+    <string name="settings_system_ime_langs">输入法语言</string>
+    <string name="settings_system_ime_langs_desc">选择应用程序可以使用的输入法键盘语言。</string>
+
+    <!-- Settings — Network tab -->
+    <string name="settings_network_connection">连接</string>
+    <string name="settings_network_playstation_network">PlayStation Network</string>
+    <string name="settings_network_http_networking">HTTP 网络</string>
+    <string name="settings_network_timeout_retry">超时与重试</string>
+    <string name="settings_network_psn_signed_in">已登录 PSN</string>
+    <string name="settings_network_psn_signed_in_desc">伪装成已登录 PlayStation Network（但处于离线状态）。</string>
+    <string name="settings_network_http_enable">启用 HTTP 网络</string>
+    <string name="settings_network_http_enable_desc">为需要 HTTP 网络功能的应用启用该支持。</string>
+    <string name="settings_network_http_timeout_attempts">超时重试次数</string>
+    <string name="settings_network_http_timeout_attempts_desc">服务器无响应时的连接重试次数。如果您的网络非常不稳定或极慢，此选项可能有用。</string>
+    <string name="settings_network_http_timeout_sleep">超时等待时间</string>
+    <string name="settings_network_http_timeout_sleep_desc">两次连接重试之间的等待时长。如果您的网络非常不稳定或极慢，此选项可能有用。</string>
+    <string name="settings_network_http_read_end_attempts">读取结束重试次数</string>
+    <string name="settings_network_http_read_end_attempts_desc">没有更多数据可读时的重试次数。数值越低性能越好，但网络状况较差时可能导致游戏不稳定。</string>
+    <string name="settings_network_http_read_end_sleep">读取结束等待时间</string>
+    <string name="settings_network_http_read_end_sleep_desc">两次读取重试之间的等待时长。数值越低性能越好，但网络状况较差时可能导致游戏不稳定</string>
+    <string name="settings_network_http_attempts_value">%1$d 次</string>
+    <string name="settings_network_http_sleep_value">%1$d ms</string>
+    <string name="settings_network_adhoc_address">Ad-Hoc 地址</string>
+    <string name="settings_network_adhoc_address_desc">选择用于 Ad-Hoc 联机的 IP 地址。</string>
+    <string name="settings_network_subnet_mask_value">子网掩码：%1$s</string>
+
+    <!-- Settings — Controls tab -->
+    <string name="settings_controls_show">显示屏幕按键</string>
+    <string name="settings_controls_show_desc">游戏运行时显示触摸按键覆盖层。</string>
+    <string name="settings_controls_hide_on_controller">连接手柄时隐藏覆盖层</string>
+    <string name="settings_controls_hide_on_controller_desc">连接实体手柄时自动隐藏触摸按键覆盖层。</string>
+    <string name="settings_controls_l2r2">显示 L2 / R2 按键</string>
+    <string name="settings_controls_l2r2_desc">在触摸覆盖层中添加额外的扳机按键。</string>
+    <string name="settings_controls_l3r3">显示 L3 / R3 按键</string>
+    <string name="settings_controls_l3r3_desc">在触摸覆盖层中添加摇杆按下按键。</string>
+    <string name="settings_controls_touch_switch">显示触摸屏切换按钮</string>
+    <string name="settings_controls_touch_switch_desc">显示用于切换前后触摸输入的按钮。</string>
+    <string name="settings_controls_hide_toggle">显示隐藏切换按钮</string>
+    <string name="settings_controls_hide_toggle_desc">显示用于临时隐藏屏幕按键的按钮。</string>
+    <string name="settings_controls_scale">按键大小</string>
+    <string name="settings_controls_scale_desc">调整触摸按键的大小，以更贴合您的手型和屏幕。</string>
+    <string name="settings_controls_opacity">按键不透明度</string>
+    <string name="settings_controls_opacity_desc">调整触摸按键在游戏画面上的透明程度。</string>
+    <string name="settings_controls_percent_value">%1$d%%</string>
+    <string name="settings_controls_controller_connected">手柄已连接</string>
+    <string name="settings_controls_controller_disconnected">未连接手柄</string>
+
+    <!-- Settings — Debug tab -->
+    <string name="settings_debug_diagnostics">诊断</string>
+    <string name="settings_debug_logging_section">日志</string>
+    <string name="settings_debug_graphics_section">图形</string>
+    <string name="settings_debug_misc_section">其他</string>
+    <string name="settings_controls_connected_title">已连接的手柄</string>
+    <string name="settings_controls_connected_desc">显示 Android 当前上报给前端的实体手柄。按键名称会尽可能沿用第一个已连接手柄的标注。</string>
+    <string name="settings_controls_connected_none">未检测到实体手柄。</string>
+    <string name="settings_controls_manual_available">即使当前没有连接手柄，您也可以手动设置按键映射。</string>
+    <string name="settings_controls_mapping_buttons_title">手柄按键映射</string>
+    <string name="settings_controls_mapping_buttons_desc">为每个输入选择对应的实体手柄按键。</string>
+    <string name="settings_controls_mapping_buttons_help">点按某一行，然后按下手柄按键，或从列表中手动选择。</string>
+    <string name="settings_controls_mapping_axes_title">摇杆与扳机映射</string>
+    <string name="settings_controls_mapping_axes_desc">选择用于驱动模拟摇杆和 PSTV 扳机的手柄轴。</string>
+    <string name="settings_controls_mapping_axes_help">点按某一行，然后拨动摇杆或扳机，或从列表中手动选择一个轴。</string>
+    <string name="settings_controls_mapping_axes_note">上和下共用同一个垂直轴，左和右共用同一个水平轴。</string>
+    <string name="settings_controls_behavior_title">手柄行为</string>
+    <string name="settings_controls_analog_multiplier">摇杆倍率</string>
+    <string name="settings_controls_analog_multiplier_desc">在摇杆输入传给模拟器之前先进行缩放。数值越高，摇杆手感越灵敏。</string>
+    <string name="settings_controls_multiplier_value">%1$.1fx</string>
+    <string name="settings_controls_disable_motion">禁用体感控制</string>
+    <string name="settings_controls_disable_motion_desc">对于需要陀螺仪或加速度计输入的游戏，忽略手柄与设备的体感传感器。</string>
+    <string name="settings_controls_capture_button_prompt">现在按下手柄按键，或从下方列表中选择映射。</string>
+    <string name="settings_controls_capture_axis_prompt">现在拨动手柄摇杆或扳机，或从下方列表中选择映射。</string>
+    <string name="settings_controls_capture_listening">正在监听手柄输入...</string>
+    <string name="settings_controls_capture_waiting_for_controller">请连接手柄以使用实时捕获。</string>
+    <string name="settings_controls_manual_selection">手动选择</string>
+    <string name="settings_controls_bind_dpad_up">方向键上</string>
+    <string name="settings_controls_bind_dpad_down">方向键下</string>
+    <string name="settings_controls_bind_dpad_left">方向键左</string>
+    <string name="settings_controls_bind_dpad_right">方向键右</string>
+    <string name="settings_controls_bind_triangle">三角</string>
+    <string name="settings_controls_bind_circle">圆圈</string>
+    <string name="settings_controls_bind_cross">叉</string>
+    <string name="settings_controls_bind_square">方块</string>
+    <string name="settings_controls_bind_l1">L1</string>
+    <string name="settings_controls_bind_r1">R1</string>
+    <string name="settings_controls_bind_l2">L2</string>
+    <string name="settings_controls_bind_r2">R2</string>
+    <string name="settings_controls_bind_l3">L3</string>
+    <string name="settings_controls_bind_r3">R3</string>
+    <string name="settings_controls_bind_select">SELECT</string>
+    <string name="settings_controls_bind_start">START</string>
+    <string name="settings_controls_bind_ps_button">PS 键</string>
+    <string name="settings_controls_bind_left_stick_up">左摇杆上</string>
+    <string name="settings_controls_bind_left_stick_down">左摇杆下</string>
+    <string name="settings_controls_bind_left_stick_left">左摇杆左</string>
+    <string name="settings_controls_bind_left_stick_right">左摇杆右</string>
+    <string name="settings_controls_bind_right_stick_up">右摇杆上</string>
+    <string name="settings_controls_bind_right_stick_down">右摇杆下</string>
+    <string name="settings_controls_bind_right_stick_left">右摇杆左</string>
+    <string name="settings_controls_bind_right_stick_right">右摇杆右</string>
+    <string name="settings_debug_log_imports">导入符号日志</string>
+    <string name="settings_debug_log_imports_desc">记录模块导入符号。</string>
+    <string name="settings_debug_log_exports">导出符号日志</string>
+    <string name="settings_debug_log_exports_desc">记录模块导出符号。</string>
+    <string name="settings_debug_log_active_shaders">记录活动着色器</string>
+    <string name="settings_debug_log_active_shaders_desc">记录当前活动的着色器程序。</string>
+    <string name="settings_debug_log_uniforms">记录着色器 Uniform</string>
+    <string name="settings_debug_log_uniforms_desc">记录着色器 uniform 变量的取值。</string>
+    <string name="settings_debug_color_surface">保存颜色表面</string>
+    <string name="settings_debug_color_surface_desc">将颜色表面保存为文件。</string>
+    <string name="settings_debug_dump_elfs">导出 ELF</string>
+    <string name="settings_debug_dump_elfs_desc">将已加载的代码导出为 ELF 文件。</string>
+    <string name="settings_debug_validation_layer">Vulkan 验证层</string>
+    <string name="settings_debug_validation_layer_desc">启用 Vulkan 验证层。\n有助于调试，但会降低性能。</string>
+
+    <!-- Settings — Emulator tab -->
+    <string name="settings_interface_appearance">外观</string>
+    <string name="settings_interface_ui_options">界面选项</string>
+    <string name="settings_emulator_behavior">行为</string>
+    <string name="settings_emulator_general">常规</string>
+    <string name="settings_emulator_logging">日志</string>
+    <string name="settings_emulator_display_overlay">显示与覆盖层</string>
+    <string name="settings_emulator_storage_capture">存储与截图</string>
+    <string name="settings_emulator_texture_cache">启用纹理缓存</string>
+    <string name="settings_emulator_texture_cache_desc">启用纹理缓存。可提升游戏性能，代价是占用更多显存。</string>
+    <string name="settings_emulator_ui_language">界面语言</string>
+    <string name="settings_emulator_ui_language_desc">选择 Android 前端使用的界面语言。\n选择“跟随系统”即使用操作系统的语言。</string>
+    <string name="settings_ui_language_system_default">跟随系统</string>
+    <string name="settings_emulator_storage_folder">模拟系统存储文件夹</string>
+    <string name="settings_emulator_storage_folder_desc">更改模拟系统存储文件夹的位置。\n如果切换到其他文件夹，请手动将已有数据迁移过去。</string>
+    <string name="settings_emulator_share_log">分享 vita3k.log</string>
+    <string name="settings_emulator_share_log_desc">打开 Android 的分享面板，以便将当前的 Vita3K 日志文件发送到 Discord 或其他应用。</string>
+    <string name="settings_emulator_storage_folder_resolve_failed">无法解析所选存储文件夹。</string>
+    <string name="settings_emulator_storage_folder_change_failed">切换模拟器存储文件夹失败。</string>
+    <string name="settings_emulator_storage_folder_change_success">已将模拟器存储文件夹切换为 %1$s。</string>
+    <string name="settings_emulator_stretch_display">拉伸显示区域</string>
+    <string name="settings_emulator_stretch_display_desc">拉伸显示区域以填满整个窗口，忽略原始宽高比。</string>
+    <string name="settings_emulator_pixel_perfect">全屏 HD 像素对齐</string>
+    <string name="settings_emulator_pixel_perfect_desc">勾选后，在 16:9 显示器上以 HD 分辨率（1080p、4K）全屏时可获得像素级精确的渲染，代价是画面顶部和底部会被略微裁切。</string>
+    <string name="settings_emulator_file_loading_delay">文件加载延迟：%1$d ms</string>
+    <string name="settings_emulator_file_loading_delay_desc">为文件加载添加人为延迟。某些游戏加载文件的速度比真机快，因而需要此设置（例如《寂静岭》）。</string>
+    <string name="settings_emulator_show_compile_shaders">显示着色器编译提示</string>
+    <string name="settings_emulator_show_compile_shaders_desc">游戏过程中编译着色器时显示提示。</string>
+    <string name="settings_emulator_check_updates">更新检查模式</string>
+    <string name="settings_emulator_check_updates_desc">选择 Vita3K 是否在启动时检查更新。\n&quot;检查&quot;会在有更新版本时通知您，&quot;不检查&quot;则会禁用启动时的检查。</string>
+    <string name="settings_emulator_check_updates_check">检查</string>
+    <string name="settings_emulator_check_updates_dont_check">不检查</string>
+    <string name="settings_emulator_archive_log">归档日志</string>
+    <string name="settings_emulator_archive_log_desc">应用运行时，额外保留一份以当前标题命名的日志文件副本。</string>
+    <string name="settings_emulator_log_compat_warn">记录兼容性警告</string>
+    <string name="settings_emulator_log_compat_warn_desc">记录与兼容性数据库相关的警告。</string>
+    <string name="settings_emulator_log_level">日志级别</string>
+    <string name="settings_emulator_log_level_desc">选择日志系统的详细程度。</string>
+    <string name="settings_emulator_perf_overlay">性能覆盖层</string>
+    <string name="settings_emulator_perf_overlay_desc">显示包含 FPS 及其他统计信息的性能覆盖层。</string>
+    <string name="settings_emulator_perf_overlay_detail">覆盖层详细程度</string>
+    <string name="settings_emulator_perf_overlay_detail_desc">选择性能覆盖层的详细程度。</string>
+    <string name="settings_emulator_perf_overlay_position">覆盖层位置</string>
+    <string name="settings_emulator_perf_overlay_position_desc">选择性能覆盖层的显示位置。</string>
+    <string name="settings_emulator_screenshot_format">截图格式</string>
+    <string name="settings_emulator_screenshot_format_desc">选择保存截图所使用的图片格式。</string>
+
+    <!-- Settings option values -->
+    <string name="settings_opt_trace">跟踪</string>
+    <string name="settings_opt_debug">调试</string>
+    <string name="settings_opt_info">信息</string>
+    <string name="settings_opt_warning">警告</string>
+    <string name="settings_opt_error">错误</string>
+    <string name="settings_opt_critical">严重</string>
+    <string name="settings_opt_off">关闭</string>
+    <string name="settings_opt_minimum">最低</string>
+    <string name="settings_opt_low">低</string>
+    <string name="settings_opt_medium">中</string>
+    <string name="settings_opt_maximum">最高</string>
+    <string name="settings_opt_top_left">左上</string>
+    <string name="settings_opt_top_center">顶部居中</string>
+    <string name="settings_opt_top_right">右上</string>
+    <string name="settings_opt_bottom_left">左下</string>
+    <string name="settings_opt_bottom_center">底部居中</string>
+    <string name="settings_opt_bottom_right">右下</string>
+    <string name="settings_opt_none">无</string>
+    <string name="settings_opt_12h">12 小时制</string>
+    <string name="settings_opt_24h">24 小时制</string>
+    <string name="settings_opt_date_ymd">YYYY/MM/DD</string>
+    <string name="settings_opt_date_dmy">DD/MM/YYYY</string>
+    <string name="settings_opt_date_mdy">MM/DD/YYYY</string>
+
+    <!-- System language options -->
+    <string name="settings_lang_japanese">日语</string>
+    <string name="settings_lang_english_us">英语（美国）</string>
+    <string name="settings_lang_french">法语</string>
+    <string name="settings_lang_spanish">西班牙语</string>
+    <string name="settings_lang_german">德语</string>
+    <string name="settings_lang_italian">意大利语</string>
+    <string name="settings_lang_dutch">荷兰语</string>
+    <string name="settings_lang_portuguese_pt">葡萄牙语（葡萄牙）</string>
+    <string name="settings_lang_russian">俄语</string>
+    <string name="settings_lang_korean">韩语</string>
+    <string name="settings_lang_chinese_trad">繁体中文</string>
+    <string name="settings_lang_chinese_simp">简体中文</string>
+    <string name="settings_lang_finnish">芬兰语</string>
+    <string name="settings_lang_swedish">瑞典语</string>
+    <string name="settings_lang_danish">丹麦语</string>
+    <string name="settings_lang_norwegian">挪威语</string>
+    <string name="settings_lang_polish">波兰语</string>
+    <string name="settings_lang_portuguese_br">葡萄牙语（巴西）</string>
+    <string name="settings_lang_english_gb">英语（英国）</string>
+    <string name="settings_lang_turkish">土耳其语</string>
+
+    <!-- IME language options -->
+    <string name="settings_ime_danish">丹麦语</string>
+    <string name="settings_ime_german">德语</string>
+    <string name="settings_ime_english_us">英语（美国）</string>
+    <string name="settings_ime_spanish">西班牙语</string>
+    <string name="settings_ime_french">法语</string>
+    <string name="settings_ime_italian">意大利语</string>
+    <string name="settings_ime_dutch">荷兰语</string>
+    <string name="settings_ime_norwegian">挪威语</string>
+    <string name="settings_ime_polish">波兰语</string>
+    <string name="settings_ime_portuguese_pt">葡萄牙语（葡萄牙）</string>
+    <string name="settings_ime_russian">俄语</string>
+    <string name="settings_ime_finnish">芬兰语</string>
+    <string name="settings_ime_swedish">瑞典语</string>
+    <string name="settings_ime_japanese">日语</string>
+    <string name="settings_ime_korean">韩语</string>
+    <string name="settings_ime_chinese_simp">简体中文</string>
+    <string name="settings_ime_chinese_trad">繁体中文</string>
+    <string name="settings_ime_portuguese_br">葡萄牙语（巴西）</string>
+    <string name="settings_ime_english_gb">英语（英国）</string>
+    <string name="settings_ime_turkish">土耳其语</string>
+
+    <!-- Trophy viewer -->
+    <string name="trophy_back_short">返回</string>
+    <string name="trophy_progress_percent_format">%1$d%%</string>
+    <string name="trophy_unlocked_count_format">已解锁 %1$d / %2$d</string>
+    <string name="trophy_error_title">无法加载奖杯</string>
+    <string name="trophy_empty_title">未找到奖杯收藏</string>
+    <string name="trophy_empty_body">安装支持奖杯的应用并至少启动一次，即可生成奖杯收藏列表。</string>
+    <string name="trophy_not_found_title">奖杯数据不可用</string>
+    <string name="trophy_not_found_body">无法从模拟器存储中加载该奖杯收藏。</string>
+    <string name="trophy_detail_not_found_body">无法从模拟器存储中加载该奖杯详情。</string>
+    <string name="trophy_hidden_title">隐藏奖杯</string>
+    <string name="trophy_hidden_detail">继续游玩即可揭示该奖杯。</string>
+    <string name="trophy_filter_all">全部</string>
+    <string name="trophy_filter_earned">已获得</string>
+    <string name="trophy_filter_locked">未获得</string>
+    <string name="trophy_filter_show_hidden">显示隐藏奖杯</string>
+    <string name="trophy_filter_empty_title">没有符合当前筛选条件的奖杯</string>
+    <string name="trophy_filter_empty_body">调整状态或等级筛选条件以显示更多奖杯。</string>
+    <string name="trophy_status_earned">已获得</string>
+    <string name="trophy_status_locked">未获得</string>
+    <string name="trophy_grade_platinum">白金</string>
+    <string name="trophy_grade_gold">金</string>
+    <string name="trophy_grade_silver">银</string>
+    <string name="trophy_grade_bronze">铜</string>
+    <string name="trophy_grade_unknown">未知</string>
+    <string name="trophy_detail_grade_label">等级</string>
+    <string name="trophy_detail_earned_label">获得时间</string>
+    <string name="trophy_detail_description_label">详情</string>
+    <string name="trophy_not_yet_earned">尚未获得</string>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -611,6 +611,7 @@
     <string name="settings_emulator_texture_cache_desc">Enable the texture cache. Improves performance in games at the cost of additional VRAM usage.</string>
     <string name="settings_emulator_ui_language">Interface Language</string>
     <string name="settings_emulator_ui_language_desc">Select the interface language used by the Android frontend.\nUse System Default to follow the operating system language.</string>
+    <string name="settings_ui_language_system_default">System Default</string>
     <string name="settings_emulator_storage_folder">Emulated System Storage Folder</string>
     <string name="settings_emulator_storage_folder_desc">Change the location of the emulated system storage folder.\nIf you move to a different folder, move your existing data there manually.</string>
     <string name="settings_emulator_share_log">Share vita3k.log</string>

--- a/android/app/src/main/res/xml/locales_config.xml
+++ b/android/app/src/main/res/xml/locales_config.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale-config xmlns:android="http://schemas.android.com/apk/res/android">
     <locale android:name="en"/>
+    <locale android:name="zh-Hans"/>
 </locale-config>


### PR DESCRIPTION
# feat(android): add Simplified Chinese (zh-Hans) UI localization

## Summary

Adds full Simplified Chinese localization to the Android frontend. The language switching infrastructure already existed (`UiLanguages` + `AppCompatDelegate.setApplicationLocales` + per-app `localeConfig`) but only shipped `en`, so this MR supplies the missing translation resources and registers the new locale.

All 658 `<string>` entries and 4 `<plurals>` groups are translated — no partial coverage, no English fallback gaps.

## Changes

| File | Change |
|---|---|
| `res/values-b+zh+Hans/strings.xml` | **New.** 658 strings + 4 plurals, fully translated |
| `res/xml/locales_config.xml` | Register `zh-Hans` for Android 13+ per-app language support |
| `res/values/strings.xml` | Add `settings_ui_language_system_default` |
| `data/UiLanguages.kt` | Add `UiLanguageOption("zh-Hans", "简体中文")` |
| `ui/screens/settings/SettingsSections.kt` | Resolve the "System Default" label from resources instead of a hardcoded literal |

### Locale tag consistency

The tag `zh-Hans` was chosen deliberately to match the existing desktop implementation, since `EmulatorConfig.userLang` round-trips into the native `config.user_lang` field via JNI (`native_config.cpp:381` / `:532`):

- `vita3k/gui-qt/src/gui_language.cpp:50` → `{ "zh-Hans", "简体中文" }`
- `vita3k/lang/src/lang.cpp:53` → `"zh-Hans"sv`

Using BCP-47 directory form `values-b+zh+Hans` (rather than `values-zh-rCN`) keeps the resource qualifier an exact match for the tag written to config. Supported on `minSdk = 28`.

### "System Default" label fix

`UiLanguages.options` previously hardcoded the English literal `"System Default"` as the first entry's label, which meant it stayed English even when the UI was switched to Chinese. It is now backed by a string resource and localized to 跟随系统. The `options` list itself is unchanged in structure, so the only consumer (`SettingsSections.kt:1478`) needed a one-line adjustment.

## Translation conventions

- Format specifiers (`%1$s`, `%1$d`, `%1$.1f`, `%%`) preserved exactly — including reordering where Chinese grammar requires it (e.g. `batch_delete_partial`, `action_deleted_success`)
- Escapes preserved (`\n`, `\u2026`, `\u00D7`, `&quot;`)
- Plurals keep both `one`/`other` items for tooling compatibility, with identical text as Chinese has no plural distinction
- Wording aligned with the existing desktop overlay translation (`i18n/lang/overlay_zh-Hans.json`) for shared concepts, so both frontends read consistently
- 24 entries intentionally left identical to English: brand names (`Vita3K`), technical acronyms (`CPU`, `DLC`, `zRIF`, `PlayStation Network`), controller face-button labels (`L1`–`R3`), date-format patterns (`YYYY/MM/DD`), and pure format strings (`%1$d KB`, `%1$.1fx`)

## Verification

- `./gradlew :app:processDebugResources` — **BUILD SUCCESSFUL** (resource merge + AAPT2 compile of the new qualifier folder)
- Automated parity check: identical key sets across both files; format-specifier multisets match per key for all 658 strings and all 8 plural items; **0 mismatches**
- `:app:compileDebugKotlin` currently fails in this environment with 24 `Cannot access 'SDLActivity'` errors. This is **pre-existing and unrelated** — the `external/sdl` submodule is not checked out locally. Verified by stashing all changes and reproducing the identical 24 errors on a clean tree.

## Notes for reviewers

`MainActivity` declares `android:configChanges="...|locale|layoutDirection|..."` (`AndroidManifest.xml:108`), so the activity is **not** recreated when the locale changes. Worth a quick on-device confirmation that Compose text recomposes immediately after selecting 简体中文 and saving. If it doesn't, the follow-up fix is to recreate the activity (or drop `locale|layoutDirection` from `configChanges`) — deliberately not changed here to keep this MR scoped to localization.

## Out of scope

Traditional Chinese (`zh-Hant`) is not included. Roughly 29 hardcoded English literals also remain outside `strings.xml` (update-check result messages in `AppRepository.kt`, trophy-loading fallbacks, controller button/axis labels in `ControllerMappingSettings.kt`), plus 4 large HTML blocks (About sheet, initial-setup guide). Separately, `normalizeSettingsSearchToken` (`SettingsSearch.kt:186`) strips CJK via `[^a-z0-9]+`, so settings search won't match Chinese queries — a functional issue best fixed on its own.
